### PR TITLE
Trasformations refactoring - New Directory

### DIFF
--- a/project/delivery_1/team4/README.md
+++ b/project/delivery_1/team4/README.md
@@ -72,8 +72,8 @@ graph
     RTS[Real-Time Server]
 
     subgraph Microservices
-		US[User service]
 		MS[Matchmaking service]
+		US[User service]
 	end
 
     GS[Game engine service]
@@ -84,10 +84,10 @@ graph
     CL --> GW
     CL --> RTS
     GW --> US
+    RTS --> US
     GW --> MS
 
     MS --> Queue1
-    GS --> Queue1
 
     RTS --> Broker1
     GS --> Broker1

--- a/project/delivery_1/team4/generation.py
+++ b/project/delivery_1/team4/generation.py
@@ -1,6 +1,7 @@
 import os
-from metamodel import create_metamodel
 from textx.export import metamodel_export, model_export
+from metamodel import create_metamodel
+from transformations import apply_transformations
 
 if __name__ == '__main__':
     metamodel = create_metamodel()
@@ -10,3 +11,6 @@ if __name__ == '__main__':
     os.makedirs('diagrams', exist_ok=True)
     metamodel_export(metamodel, 'diagrams/metamodel.dot')
     model_export(model, 'diagrams/model.dot')
+
+    # Transformations
+    apply_transformations(model)

--- a/project/delivery_1/team4/model.arch
+++ b/project/delivery_1/team4/model.arch
@@ -9,7 +9,7 @@ architecture TicTacToe :
 
     component broker PubSubRealTimeBroker
     component queue GameMatchingQueue
-    component cache OnlineGamesCache
+    component database OnlineGamesCache
 
     connector web_socket WebApp -> RealTimeService
 

--- a/project/delivery_1/team4/transformations/__init__.py
+++ b/project/delivery_1/team4/transformations/__init__.py
@@ -1,0 +1,20 @@
+from transformations import database, gateway
+
+def apply_transformations(model):
+    components = {}
+
+    print(model.elements)
+
+    for e in model.elements:
+        if e.__class__.__name__ == "Component":
+            components[e.name] = e
+            if e.type == "database":
+                database.generate_database(e.name)
+            if e.type == "gateway":
+                gateway.generate_gateway(e.name, model)
+            # if e.type == "service":
+            #     generate_database(e.name)
+            # if e.type == "frontend":
+            #     generate_database(e.name)
+
+    # generate_docker_compose(components)

--- a/project/delivery_1/team4/transformations/database.py
+++ b/project/delivery_1/team4/transformations/database.py
@@ -1,0 +1,4 @@
+from transformations.templates import generate_templated_component
+
+def generate_database(name):
+    generate_templated_component(name, "database")

--- a/project/delivery_1/team4/transformations/dockercompose.py
+++ b/project/delivery_1/team4/transformations/dockercompose.py
@@ -1,0 +1,4 @@
+from transformations.templates import _make_component_dir
+
+def generate_docker_compose(components):
+    path = _make_component_dir("")

--- a/project/delivery_1/team4/transformations/gateway.py
+++ b/project/delivery_1/team4/transformations/gateway.py
@@ -1,0 +1,7 @@
+def generate_gateway(name, model):
+    services = {}
+    print("gateway name:", name)
+
+    for e in model.elements:
+        if e.__class__.__name__ == "Connector":
+            print("Connector: ", "from ", e.from_, "to ", e.to_)

--- a/project/delivery_1/team4/transformations/templates.py
+++ b/project/delivery_1/team4/transformations/templates.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 PROJECT_BASE = Path.cwd() / "skeleton"
-TEMPLATES_BASE = Path(__file__).parent / "templates"
+TEMPLATES_BASE = Path.cwd() / "templates"
 
 #Create the location for a given component
 def _make_component_dir(component_name: str, project_base: Path = PROJECT_BASE) -> Path:
@@ -29,22 +29,3 @@ def _copy_template(template_path: Path, target_path: Path, params: dict | None =
 def generate_templated_component(name: str, template_name: str, params: dict = None) -> None:
     path = _make_component_dir(name)
     _copy_template(template_path=TEMPLATES_BASE / template_name, target_path=path, params=params)
-
-
-def generate_database(name):
-    generate_templated_component(name, "database")
-
-
-def generate_docker_compose(components):
-    path = _make_component_dir("")
-
-def apply_transformations(model):
-    components = {}
-
-    for e in model.elements:
-        if e.__class__.__name__ == "Component":
-            components[e.name] = e
-            if e.type == "database":
-                generate_database(e.name)
-
-    # generate_docker_compose(components)


### PR DESCRIPTION
Context

We were facing merge conflicts and coordination issues while working simultaneously on the transformations.py file. To improve collaboration and avoid stepping on each other's toes, I proposed refactoring the transformations into a modular folder-based structure.

Changes Made

  - Created a transformations/ directory.
  - Moved each transformation into its own file (e.g., transformation_a.py, transformation_b.py).
  - Added an __init__.py as the main entry point, responsible for importing and exposing the individual transformations.
  - Maintained backward compatibility for existing imports (if needed).

Benefits

  - Enables parallel development without conflicts.
  - Improves code organization and readability.
  - Makes each transformation easier to test and maintain independently.